### PR TITLE
Various fixes and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,35 +87,17 @@ ardi board list
 ardi board list mega
 ```
 
-# Creating and uploading Sketches
+# Uploading Sketches
 
-There are two options for compiling and uploading sketches.
-Both options require your sketch `.ino` file to be in a
-directory that matches the `.ino` file name.</br>
-e.g. `blink/blink.ino`
+Point ardi at any absolute or relative path to a sketch directory.
 
-**Using a project level "sketches" directory:**
+    ardi go ~/<project_root>/<project_sub_dir>/blink/ --verbose
 
-- create a sketches directory in your project folder
-- add your sketch directory to the sketches directory</br>
-  e.g. `<project>/sketches/blink/blink.ino`
-- From the root of your project run
-  `ardi go <name_of_sketch_directory> --verbose`</br>
-  e.g. `ardi go blink --verbose`
+By default ardi will connect to the serial port and print logs. Ardi will read
+the sketch file and attempt to auto-detect the baud rate. To manually specify
+the baud rate run:
 
-**Using an absolute or relative path to sketch directory:**
-
-- point ardi at any absolute or relative path to a
-  sketch directory.</br>
-  e.g. `ardi go ~/<project_root>/<project_sub_dir>/blink/ --verbose`
-
-By default ardi will connect to the serial port and print
-logs. Ardi will read the sketch file and attempt to
-auto-detect the baud rate. To manually specify the baud
-rate run:</br>
-`ardi go <sketch_name> --baud <BAUD_RATE>`
-
-For a list of all ardi options run: `ardi --help` or `ardi [command] --help`.
+    ardi go <path_to_sketch_dir> --baud <baud_rate>
 
 # Using ardi's "watch" feature
 
@@ -123,11 +105,7 @@ Ardi allows you to optionally watch a specified sketch file for changes and
 auto re-compile and re-upload. Just add the `--watch` flag to the `ardi go`
 command.
 
-```bash
-ardi go blink --watch
-#or
-ardi go <path_to_sketch_dir> --watch
-```
+    ardi go <path_to_sketch_dir> --watch
 
 # Compiling only (no upload)
 
@@ -138,7 +116,7 @@ board, run the compile command with no --fqbn argument and ardi will present
 you with a list of board names and their associated fqbns for each installed
 platform.
 
-    ardi compile <sketch_directory> --fqbn <board_fqbn>
+    ardi compile <sketch_directory> --fqbn <board_fqbn> --verbose
 
 # Adding Libraries
 

--- a/ardi/ardi.go
+++ b/ardi/ardi.go
@@ -62,19 +62,6 @@ type TargetInfo struct {
 	Logging      bool
 }
 
-type platformUpgradeMessage struct {
-	platformPackage string
-	architecture    string
-	success         bool
-}
-
-type platformInstallMessage struct {
-	platformPackage string
-	architecture    string
-	version         string
-	success         bool
-}
-
 type boardInfo struct {
 	FQBN string
 	Name string
@@ -581,8 +568,7 @@ func Initialize(platform, version string) {
 		platPackage := platParts[0]
 		arch := platParts[len(platParts)-1]
 		version := ""
-		done := make(chan platformInstallMessage, 1)
-		platformInstall(client, rpcInstance, platPackage, arch, version, done)
+		platformInstall(client, rpcInstance, platPackage, arch, version)
 	}
 	if !isVerbose() {
 		quit <- true

--- a/commands/compile.go
+++ b/commands/compile.go
@@ -3,11 +3,13 @@ package commands
 import (
 	"github.com/robgonnella/ardi/ardi"
 	"github.com/robgonnella/ardi/arguments"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 func getCompileCommand() *cobra.Command {
 	var fqbn string
+	var verbose bool
 	var compileCmd = &cobra.Command{
 		Use:   "compile [sketch]",
 		Short: "Compile specified sketch",
@@ -15,6 +17,11 @@ func getCompileCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			if !ardi.IsInitialized() {
 				logger.Fatal("Ardi has not been initialized. Please run \"ardi init\" first")
+			}
+			if verbose {
+				ardi.SetLogLevel(log.DebugLevel)
+			} else {
+				ardi.SetLogLevel(log.InfoLevel)
 			}
 
 			configFile := ardi.GlobalLibConfig
@@ -48,6 +55,8 @@ func getCompileCommand() *cobra.Command {
 			ardi.Compile(client, instance, target)
 		},
 	}
-	compileCmd.Flags().StringVarP(&fqbn, "fqbn", "f", "", "specify fully qualified board name")
+	compileCmd.Flags().StringVarP(&fqbn, "fqbn", "f", "", "Specify fully qualified board name")
+	compileCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Print all compilation logs")
+
 	return compileCmd
 }


### PR DESCRIPTION
- Remove all goroutines from initialization process and just run
  synchronously. Until more data can be gathered about cpu and
  memory usage this a safer approach even though it is slower
- Add ability to run the compile command with the "--verbose" flag
- Better handling of sketch directory and sketch file paths