### PR TITLE
Minor tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ Ardi's `--watch` flag allows you to auto re-compile and upload on save, saving
 you time and improving efficiency.
 
 Ardi should work for all boards and platforms supported by arduino-cli.
-Run `ardi init` to download all supported platforms and indexes to ensure
+Run `ardi init` to download all supported platforms and index files to ensure
 maximum board support. To initialize only for a specific platform, run
-`ardi init <platformID>`. To see a list of supported platforms and associated
-IDs, run `ardi platform list`. To see a list of all supported boards and their
-associated platforms and fqbns run `ardi board list`.
+`ardi init <platformID>` or `ardi init <platformID@version>`. To see a list of
+supported platforms and associated IDs, run `ardi platform list`. To see a list
+of all supported boards and their associated platforms and fqbns run
+`ardi board list`.
+(Note board fqbn will only be filled in once platform is initialized)
 
 Once initialized run `ardi go <sketch_dir> --watch --verbose` and ardi will try
 to auto detect your board, compile your sketch, upload, watch for changes in
@@ -58,9 +60,18 @@ Use "ardi [command] --help" for more information about a command.
 ardi init --verbose
 # or to initialize only for a specified platform
 ardi init --verbose <platform_id>
+# or to initialize for a specific version of a platform
+ardi init --verbose <platform_id@version>
 # to list the available platforms
 ardi platform list <optional_search_param>
 ```
+
+Note: Unfortunately, at this time ardi cannot provide a list of available
+versions for each platform. However, you can find some of the arduino
+platforms (aka cores) listed
+[here](https://github.com/arduino?utf8=%E2%9C%93&q=core&type=&language=). Click
+on your desired platform / core, then click on the "releases" tab to see
+a list of versions for that platform / core.
 
 # Remove all installed platforms and data
 

--- a/ardi/util.go
+++ b/ardi/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sort"
 	"text/tabwriter"
 	"time"
 
@@ -25,6 +26,9 @@ func createDataDir() {
 }
 
 func printConnectedBoardsWithIndices(list []TargetInfo) {
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].BoardName < list[j].BoardName
+	})
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 8, ' ', 0)
 	defer w.Flush()
 	fmt.Fprintln(w, "No.\tBoard\tDevice")
@@ -34,6 +38,9 @@ func printConnectedBoardsWithIndices(list []TargetInfo) {
 }
 
 func printSupportedBoardsWithIndices(boards []boardInfo) {
+	sort.Slice(boards, func(i, j int) bool {
+		return boards[i].Name < boards[j].Name
+	})
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 8, ' ', 0)
 	defer w.Flush()
 	fmt.Fprintln(w, "No.\tName\tFQBN")

--- a/commands/compile.go
+++ b/commands/compile.go
@@ -13,7 +13,6 @@ func getCompileCommand() *cobra.Command {
 	var compileCmd = &cobra.Command{
 		Use:   "compile [sketch]",
 		Short: "Compile specified sketch",
-		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			if !ardi.IsInitialized() {
 				logger.Fatal("Ardi has not been initialized. Please run \"ardi init\" first")
@@ -32,7 +31,13 @@ func getCompileCommand() *cobra.Command {
 			conn, client, instance := ardi.StartDaemonAndGetConnection(configFile)
 			defer conn.Close()
 
-			sketchDir, sketchFile := arguments.GetSketchParts(args[0])
+			sketchDir := "."
+			sketchFile := ""
+			if len(args) > 0 {
+				sketchDir = args[0]
+			}
+
+			sketchDir, sketchFile = arguments.GetSketchParts(sketchDir)
 			list := ardi.GetTargetList(client, instance, sketchDir, sketchFile, 9600)
 			var target *ardi.TargetInfo
 

--- a/commands/init.go
+++ b/commands/init.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"strings"
+
 	"github.com/robgonnella/ardi/ardi"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -23,10 +25,13 @@ func getInitCommand() *cobra.Command {
 			platform := ""
 			version := ""
 			if len(args) > 0 {
-				platform = args[0]
-			}
-			if len(args) > 1 {
-				version = args[1]
+				platParts := strings.Split(args[0], "@")
+				if len(platParts) > 0 {
+					platform = platParts[0]
+				}
+				if len(platParts) > 1 {
+					version = platParts[1]
+				}
 			}
 			logger.Info("Initializing. This may take some time...")
 			ardi.Initialize(platform, version)

--- a/main.go
+++ b/main.go
@@ -7,11 +7,13 @@ Ardi's "--watch" flag allows you to auto re-compile and upload on save, saving
 you time and improving efficiency.
 
 Ardi should work for all boards and platforms supported by arduino-cli.
-Run "ardi init" to download all supported platforms and indexes to ensure
+Run "ardi init" to download all supported platforms and index files to ensure
 maximum board support. To initialize only for a specific platform, run
-"ardi init <platformID>". To see a list of supported platforms and associated
-IDs, run "ardi platform list". To see a list of all supported boards and their
-associated platforms and fqbns run "ardi board list".
+"ardi init <platformID>" or "ardi init <platformID@version>". To see a list of
+supported platforms and associated IDs, run "ardi platform list". To see a list
+of all supported boards and their associated platforms and fqbns run
+"ardi board list".
+(Note board fqbn will only be filled in once platform is initialized)
 
 Once initialized run "ardi go <sketch_dir> --watch --verbose" and ardi will try
 to auto detect your board, compile your sketch, upload, watch for changes in


### PR DESCRIPTION
- Sort output of list commands alphabetically, with exception of
  board list command as that one seems better as is (sorted by
  platform id)
- Allow compile command to be run using current directory
  as default sketch directory
- Allow user to initialize for a specific version of a specified
  platform