### PR TITLE
Fix issues with attach-and-watch command

### DIFF
--- a/v2/commands/attach_and_watch.go
+++ b/v2/commands/attach_and_watch.go
@@ -1,6 +1,10 @@
 package commands
 
 import (
+	"os"
+	"os/signal"
+	"syscall"
+
 	cli "github.com/robgonnella/ardi/v2/cli-wrapper"
 	"github.com/robgonnella/ardi/v2/core"
 	"github.com/robgonnella/ardi/v2/util"
@@ -64,6 +68,16 @@ func getWatchCmd() *cobra.Command {
 				Baud:        baud,
 			}
 			ardiCore.Watcher.SetTargets(targets)
+
+			sigs := make(chan os.Signal, 1)
+			signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+			go func() {
+				<-sigs
+				logger.Debug("gracefully shutting down attach-and-watch")
+				ardiCore.Watcher.Stop()
+			}()
+
 			return ardiCore.Watcher.Watch()
 		},
 	}

--- a/v2/core/file_watcher.go
+++ b/v2/core/file_watcher.go
@@ -2,9 +2,6 @@ package core
 
 import (
 	"errors"
-	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/fsnotify/fsnotify"
 	log "github.com/sirupsen/logrus"
@@ -16,9 +13,10 @@ type Listener = func()
 // FileWatcher watches sketch files for changes and runs user defined actions
 type FileWatcher struct {
 	file      string
+	stop      chan bool
+	close     chan bool
+	restart   chan bool
 	watcher   *fsnotify.Watcher
-	destroyed bool
-	pause     chan bool
 	listeners []Listener
 	logger    *log.Logger
 }
@@ -35,26 +33,15 @@ func NewFileWatcher(file string, logger *log.Logger) (*FileWatcher, error) {
 		return nil, err
 	}
 
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-
-	pause := make(chan bool, 1)
-
-	fileWatcher := &FileWatcher{
+	return &FileWatcher{
 		file:      file,
 		watcher:   watcher,
-		pause:     pause,
+		stop:      make(chan bool, 1),
+		close:     make(chan bool, 1),
+		restart:   make(chan bool, 1),
 		listeners: []Listener{},
 		logger:    logger,
-	}
-
-	go func() {
-		<-sigs
-		logger.Debug("gracefully shutting down file watcher")
-		fileWatcher.Close()
-	}()
-
-	return fileWatcher, nil
+	}, nil
 }
 
 // AddListener adds an action to run on file change
@@ -64,64 +51,84 @@ func (f *FileWatcher) AddListener(l Listener) {
 
 // Watch watches the file for changes and runs user defined actions
 func (f *FileWatcher) Watch() error {
-	if f.destroyed {
-		f.logger.Debug("file watcher has been destroyed")
-		return nil
+	if f.watcher == nil {
+		return errors.New("file watcher already closed")
 	}
 
 	f.logger.Infof("Watching %s for changes", f.file)
+
 	for {
-		if f.destroyed {
-			f.logger.Debug("file watcher has been destroyed")
+		if f.watcher == nil {
+			f.logger.Debug("file watcher already closed")
 			return nil
 		}
 
 		select {
-		case <-f.pause:
-			f.pause <- true
+		case <-f.stop:
+			f.watcher.Remove(f.file)
+			f.stop <- true
+		case <-f.restart:
+			f.watcher.Add(f.file)
+			f.restart <- true
+		case <-f.close:
+			f.watcher.Remove(f.file)
+			f.watcher.Close()
+			f.watcher = nil
 			return nil
 		case event, ok := <-f.watcher.Events:
 			if !ok {
-				err := errors.New("failed to watch")
-				f.logger.WithError(err).Debug()
-				return err
+				f.logger.Error("unknown file watch error")
+				return nil
 			}
 			f.logger.Debugf("event: %+v", event)
 			if event.Op&fsnotify.Write == fsnotify.Write {
 				f.logger.Debugf("modified file: %s", event.Name)
 				for _, l := range f.listeners {
-					l()
+					go l()
 				}
 			}
 		case err, ok := <-f.watcher.Errors:
 			if !ok {
+				f.logger.Debug("unknown file watch error")
 				return nil
 			}
-			f.logger.WithError(err).Warn("Watch error")
+			f.watcher.Close()
+			f.watcher = nil
+			f.logger.WithError(err).Error("Watch error")
 			return err
 		}
 	}
 }
 
-// Close closes the os watcher, watcher can not be restarted
-func (f *FileWatcher) Close() {
-	if f.watcher != nil {
-		f.watcher.Close()
-		f.watcher.Remove(f.file)
-		f.destroyed = true
-	}
-}
-
-// Stop stops watching file with ability to restart at any time
+// Stop stops the os watcher
 func (f *FileWatcher) Stop() {
-	f.pause <- true
-	<-f.pause
-	f.watcher.Remove(f.file)
-	f.logger.WithField("file", f.file).Debug("file watcher paused")
+	loggerWithField := f.logger.WithField("file", f.file)
+	if f.watcher != nil {
+		loggerWithField.Info("Stopping file watcher")
+		f.stop <- true
+		<-f.stop
+	}
+	loggerWithField.Info("File watcher stopped")
 }
 
-// Restart restarts existing watcher
+// Restart restarts the file watcher after being stopped
 func (f *FileWatcher) Restart() {
-	f.watcher.Add(f.file)
-	f.Watch()
+	loggerWithField := f.logger.WithField("file", f.file)
+	if f.watcher != nil {
+		loggerWithField.Info("Restarting file watcher")
+		f.restart <- true
+		<-f.restart
+	}
+	loggerWithField.Info("File watcher restarted")
+}
+
+// Close fully closes file watcher (cannot be restarted)
+func (f *FileWatcher) Close() {
+	loggerWithField := f.logger.WithField("file", f.file)
+	if f.watcher != nil {
+		loggerWithField.Info("Closing file watcher")
+		f.close <- true
+		<-f.close
+	}
+	loggerWithField.Info("file watcher closed")
 }

--- a/v2/core/file_watcher_test.go
+++ b/v2/core/file_watcher_test.go
@@ -32,7 +32,7 @@ func TestFileWatcher(t *testing.T) {
 
 		listener := func() {
 			env.Logger.Info(successMsg)
-			watcher.Close()
+			watcher.Stop()
 		}
 		watcher.AddListener(listener)
 

--- a/v2/core/serial_test.go
+++ b/v2/core/serial_test.go
@@ -29,8 +29,8 @@ func TestSerialPort(t *testing.T) {
 		port := core.NewArdiSerialPort(device, baud, logger)
 
 		st.Cleanup(func() {
-			if port.IsStreaming() {
-				port.Stop()
+			if port.Streaming() {
+				port.Close()
 			}
 			port = nil
 		})
@@ -38,14 +38,14 @@ func TestSerialPort(t *testing.T) {
 		go port.Watch()
 
 		time.Sleep(time.Second)
-		assert.True(st, port.IsStreaming())
+		assert.True(st, port.Streaming())
 
 		msg := "this is a tty message\n"
 		cmd := exec.Command("echo", "-e", msg, ">>", device)
 		err := cmd.Run()
 		assert.NoError(st, err)
 
-		port.Stop()
-		assert.False(st, port.IsStreaming())
+		port.Close()
+		assert.False(st, port.Streaming())
 	})
 }

--- a/v2/core/upload.go
+++ b/v2/core/upload.go
@@ -12,6 +12,7 @@ type UploadCore struct {
 	logger    *log.Logger
 	cli       *cli.Wrapper
 	uploading bool
+	port      SerialPort
 }
 
 // NewUploadCore returns new ardi upload core
@@ -43,11 +44,20 @@ func (c *UploadCore) Upload(board *cli.BoardWithPort, buildDir string) error {
 // Attach attaches to the associated board port and prints logs
 func (c *UploadCore) Attach(device string, baud int, port SerialPort) {
 	if port == nil {
-		port = NewArdiSerialPort(device, baud, c.logger)
+		c.port = NewArdiSerialPort(device, baud, c.logger)
 	} else {
-		port.Stop()
+		c.port = port
+		port.Close()
 	}
-	port.Watch()
+	c.port.Watch()
+}
+
+// Detach detaches from the associated board port
+func (c *UploadCore) Detach() {
+	if c.port != nil {
+		c.port.Close()
+		c.port = nil
+	}
 }
 
 // IsUploading returns whether or not core is currently uploading

--- a/v2/core/upload_test.go
+++ b/v2/core/upload_test.go
@@ -58,7 +58,7 @@ func TestUploadCore(t *testing.T) {
 		baud := 9600
 		port := mocks.NewMockSerialPort(env.Ctrl)
 
-		port.EXPECT().Stop().Times(1)
+		port.EXPECT().Close().Times(1)
 		port.EXPECT().Watch().Times(1)
 		env.ArdiCore.Uploader.Attach(device, baud, port)
 	})

--- a/v2/core/watch_test.go
+++ b/v2/core/watch_test.go
@@ -35,7 +35,7 @@ func TestWatchCore(t *testing.T) {
 		cpCmd := exec.Command("cp", sketchCopy, sketch)
 		env.ClearStdout()
 		port := mocks.NewMockSerialPort(env.Ctrl)
-		port.EXPECT().Stop().AnyTimes()
+		port.EXPECT().Close().AnyTimes()
 		port.EXPECT().Watch().AnyTimes()
 
 		instance := &rpc.Instance{Id: int32(1)}
@@ -79,14 +79,13 @@ func TestWatchCore(t *testing.T) {
 
 		assert.Contains(env.T, env.Stdout.String(), "Reuploading")
 		assert.Contains(env.T, env.Stdout.String(), "Upload successful")
-		env.ArdiCore.Watcher.Stop()
 	})
 
 	testutil.RunUnitTest("does not reupload on compilation error", t, func(env *testutil.UnitTestEnv) {
 		cpCmd := exec.Command("cp", sketchCopy, sketch)
 		env.ClearStdout()
 		port := mocks.NewMockSerialPort(env.Ctrl)
-		port.EXPECT().Stop().AnyTimes()
+		port.EXPECT().Close().AnyTimes()
 		port.EXPECT().Watch().Times(1)
 
 		dummyErr := errors.New("dummy errror")
@@ -131,6 +130,5 @@ func TestWatchCore(t *testing.T) {
 
 		assert.NotContains(env.T, env.Stdout.String(), "Reuploading")
 		assert.NotContains(env.T, env.Stdout.String(), "Upload successful")
-		env.ArdiCore.Watcher.Stop()
 	})
 }

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -30,9 +30,8 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.8.1 // indirect
 	github.com/stretchr/testify v1.7.0
-	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
-	go.bug.st/serial v1.1.3 // indirect
+	go.bug.st/serial v1.1.3
 	go.bug.st/serial.v1 v0.0.0-20191202182710-24a6610f0541 // indirect
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -452,8 +452,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07 h1:UyzmZLoiDWMRywV4DUYb9Fbt8uiOSooupjTq10vpvnU=
-github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=

--- a/v2/mocks/mock_serial.go
+++ b/v2/mocks/mock_serial.go
@@ -33,30 +33,30 @@ func (m *MockSerialPort) EXPECT() *MockSerialPortMockRecorder {
 	return m.recorder
 }
 
-// IsStreaming mocks base method.
-func (m *MockSerialPort) IsStreaming() bool {
+// Close mocks base method.
+func (m *MockSerialPort) Close() {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsStreaming")
+	m.ctrl.Call(m, "Close")
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockSerialPortMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockSerialPort)(nil).Close))
+}
+
+// Streaming mocks base method.
+func (m *MockSerialPort) Streaming() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Streaming")
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// IsStreaming indicates an expected call of IsStreaming.
-func (mr *MockSerialPortMockRecorder) IsStreaming() *gomock.Call {
+// Streaming indicates an expected call of Streaming.
+func (mr *MockSerialPortMockRecorder) Streaming() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStreaming", reflect.TypeOf((*MockSerialPort)(nil).IsStreaming))
-}
-
-// Stop mocks base method.
-func (m *MockSerialPort) Stop() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Stop")
-}
-
-// Stop indicates an expected call of Stop.
-func (mr *MockSerialPortMockRecorder) Stop() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockSerialPort)(nil).Stop))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Streaming", reflect.TypeOf((*MockSerialPort)(nil).Streaming))
 }
 
 // Watch mocks base method.


### PR DESCRIPTION
There were timing issues with pausing the serial port watcher before
re-uploading to the arduino board. This addresses those issues by
using channels to have better control of when the port if fully closed.
Additionally improvements were made to the file watcher logic allowing
each listener to run in it's own goroutine.