### PR TITLE
Fix issues with auto detection in upload and attach-and-watch

### DIFF
--- a/v2/commands/attach_and_watch_test.go
+++ b/v2/commands/attach_and_watch_test.go
@@ -161,4 +161,77 @@ func TestAttachAndWatchCommand(t *testing.T) {
 		assert.Contains(env.T, env.Stdout.String(), "Upload successful")
 		os.Chdir(cwd)
 	})
+
+	testutil.RunIntegrationTest("attaches and watches using auto detected values", t, func(env *testutil.IntegrationTestEnv) {
+		ctrl := gomock.NewController(env.T)
+		inst := mocks.NewMockCli(ctrl)
+
+		board := testutil.GenerateRPCBoard("Arduino Mega", "arduino:avr:mega")
+
+		sketchDir := testutil.BlinkProjectDir()
+		sketch := path.Join(sketchDir, "blink.ino")
+		sketchCopy := path.Join(testutil.BlinkCopyProjectDir(), "blink2.ino")
+		fqbn := testutil.ArduinoMegaFQBN()
+		cpCmd := exec.Command("cp", sketchCopy, sketch)
+
+		instance := &rpc.Instance{Id: int32(1)}
+		uploadReq := &rpc.UploadRequest{
+			Instance:   instance,
+			Fqbn:       fqbn,
+			SketchPath: sketchDir,
+			Port:       board.Port,
+		}
+
+		platformReq := &rpc.PlatformListRequest{
+			Instance:      instance,
+			UpdatableOnly: false,
+			All:           true,
+		}
+
+		compileReq := &rpc.CompileRequest{
+			Instance:        instance,
+			Fqbn:            board.FQBN,
+			SketchPath:      sketch,
+			ExportDir:       path.Join(sketchDir, "build"),
+			BuildProperties: []string{},
+			ShowProperties:  false,
+		}
+
+		boardItem := &rpc.BoardListItem{
+			Name: board.Name,
+			Fqbn: board.FQBN,
+		}
+		port := &rpc.DetectedPort{
+			Address: board.Port,
+			Boards:  []*rpc.BoardListItem{boardItem},
+		}
+		detectedPorts := []*rpc.DetectedPort{port}
+
+		cwd, _ := os.Getwd()
+		os.Chdir(testutil.BlinkProjectDir())
+		err := env.RunProjectInit()
+		assert.NoError(env.T, err)
+
+		inst.EXPECT().CreateInstance().Return(instance).AnyTimes()
+		inst.EXPECT().Compile(gomock.Any(), compileReq, gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		inst.EXPECT().ConnectedBoards(instance.GetId()).Return(detectedPorts, nil)
+		inst.EXPECT().GetPlatforms(platformReq)
+		inst.EXPECT().Upload(gomock.Any(), uploadReq, gomock.Any(), gomock.Any()).AnyTimes()
+
+		args := []string{"attach-and-watch"}
+		go env.ExecuteWithMockCli(args, inst)
+
+		time.Sleep(time.Second * 5)
+
+		env.ClearStdout()
+		err = cpCmd.Run()
+		assert.NoError(env.T, err)
+
+		// wait a second for watcher to trigger
+		time.Sleep(time.Second)
+
+		assert.Contains(env.T, env.Stdout.String(), "Reuploading")
+		assert.Contains(env.T, env.Stdout.String(), "Upload successful")
+		os.Chdir(cwd)
+	})
 }

--- a/v2/commands/upload_test.go
+++ b/v2/commands/upload_test.go
@@ -77,6 +77,17 @@ func TestUploadCommand(t *testing.T) {
 			assert.NoError(st, err)
 		})
 
+		env.T.Run("uploads a sketch using auto detected values", func(st *testing.T) {
+			inst.EXPECT().CreateInstance().Return(instance).AnyTimes()
+			inst.EXPECT().ConnectedBoards(instance.GetId()).Return(detectedPorts, nil)
+			inst.EXPECT().GetPlatforms(platformReq)
+			inst.EXPECT().Upload(gomock.Any(), req, gomock.Any(), gomock.Any())
+
+			args = []string{"upload", sketch}
+			err = env.ExecuteWithMockCli(args, inst)
+			assert.NoError(st, err)
+		})
+
 		env.T.Run("returns upload errors", func(st *testing.T) {
 			dummyErr := errors.New("dummy")
 			inst.EXPECT().CreateInstance().Return(instance).AnyTimes()
@@ -91,6 +102,9 @@ func TestUploadCommand(t *testing.T) {
 		})
 
 		env.T.Run("errors if sketch not found", func(st *testing.T) {
+			inst.EXPECT().CreateInstance().Return(instance).AnyTimes()
+			inst.EXPECT().ConnectedBoards(instance.GetId()).Return([]*rpc.DetectedPort{}, nil)
+			inst.EXPECT().GetPlatforms(platformReq)
 			args = []string{"upload", "--fqbn", fqbn, bogusSketch}
 			err = env.ExecuteWithMockCli(args, inst)
 			assert.Error(st, err)

--- a/v2/util/util.go
+++ b/v2/util/util.go
@@ -315,7 +315,8 @@ func findSketch(directory string) (string, error) {
 	}
 
 	sketchFile := ""
-	searchName := fmt.Sprintf("%s.ino", filepath.Base(directory))
+	absPath, _ := filepath.Abs(directory)
+	searchName := fmt.Sprintf("%s.ino", filepath.Base(absPath))
 
 	d, err := os.Open(directory)
 	if err != nil {


### PR DESCRIPTION
Try to auto detect the board first then fall back to user defined
overrides. Also use the absolute filepath when getting base directory
name otherwise you can wind up with "." for directory name.

issue #54 