### PR TITLE
Add attach command

### DIFF
--- a/v2/commands/attach.go
+++ b/v2/commands/attach.go
@@ -1,0 +1,32 @@
+package commands
+
+import (
+	"github.com/robgonnella/ardi/v2/core"
+	"github.com/spf13/cobra"
+)
+
+func getAttachCmd() *cobra.Command {
+	var port string
+	var baud int
+	var attachCmd = &cobra.Command{
+		Use:   "attach",
+		Short: "Attach and print board logs",
+		Long:  "\nAttach and print board logs",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if port == "" {
+				board, err := ardiCore.Cli.GetTargetBoard("", "", true)
+				if err != nil {
+					return err
+				}
+				port = board.Port
+			}
+			serialPort := core.NewArdiSerialPort(port, baud, logger)
+			defer serialPort.Close()
+			return serialPort.Watch()
+		},
+	}
+
+	attachCmd.Flags().StringVarP(&port, "port", "p", "", "The port your arduino board is connected to")
+	attachCmd.Flags().IntVarP(&baud, "baud", "b", 9600, "Specify baud rate of port")
+	return attachCmd
+}

--- a/v2/commands/root.go
+++ b/v2/commands/root.go
@@ -67,9 +67,14 @@ func cmdIsVersion(cmd string) bool {
 	return cmd == "ardi version"
 }
 
+func cmdIsArdiAttach(cmd string) bool {
+	return cmd == "ardi attach"
+}
+
 func shouldShowProjectError(cmd string) bool {
 	return !util.IsProjectDirectory() &&
 		!cmdIsProjectInit(cmd) &&
+		!cmdIsArdiAttach(cmd) &&
 		!cmdIsHelp(cmd) &&
 		!cmdIsVersion(cmd)
 }
@@ -144,5 +149,6 @@ func GetRootCmd(cmdLogger *log.Logger, instance cli.Cli) *cobra.Command {
 	rootCmd.AddCommand(getUploadCmd())
 	rootCmd.AddCommand(getVersionCmd())
 	rootCmd.AddCommand(getWatchCmd())
+	rootCmd.AddCommand(getAttachCmd())
 	return rootCmd
 }

--- a/v2/docs/ardi.md
+++ b/v2/docs/ardi.md
@@ -24,6 +24,7 @@ Ardi is a build tool that allows you to completely manage your arduino project f
 ### SEE ALSO
 
 * [ardi add](ardi_add.md)	 - Add project dependencies
+* [ardi attach](ardi_attach.md)	 - Attach and print board logs
 * [ardi attach-and-watch](ardi_attach-and-watch.md)	 - Compile, upload, watch board logs, and watch for sketch changes
 * [ardi clean](ardi_clean.md)	 - Delete project data directory
 * [ardi compile](ardi_compile.md)	 - Compile specified sketch or build(s)

--- a/v2/docs/ardi_attach.md
+++ b/v2/docs/ardi_attach.md
@@ -1,0 +1,32 @@
+## ardi attach
+
+Attach and print board logs
+
+### Synopsis
+
+
+Attach and print board logs
+
+```
+ardi attach [flags]
+```
+
+### Options
+
+```
+  -b, --baud int      Specify baud rate of port (default 9600)
+  -h, --help          help for attach
+  -p, --port string   The port your arduino board is connected to
+```
+
+### Options inherited from parent commands
+
+```
+  -q, --quiet     Silence all logs
+  -v, --verbose   Print all logs
+```
+
+### SEE ALSO
+
+* [ardi](ardi.md)	 - Ardi is a command line build manager for arduino projects.
+


### PR DESCRIPTION
Allows user to attach to a board and watch logs without needing to
compile or watch files for changes.

Issue #52