### PR TITLE
Fix completions

### DIFF
--- a/v2/commands/add.go
+++ b/v2/commands/add.go
@@ -12,6 +12,9 @@ func getAddPlatformCmd(env *CommandEnv) *cobra.Command {
 		Aliases: []string{"platform"},
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			for _, p := range args {
 				env.Logger.Infof("Adding platform: %s", p)
 				installed, vers, err := env.ArdiCore.Platform.Add(p)
@@ -41,6 +44,9 @@ func getAddBuildCmd(env *CommandEnv) *cobra.Command {
 		Long:  "\nAdd build config to project",
 		Short: "Add build config to project",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			return env.ArdiCore.Config.AddBuild(name, sketch, fqbn, baud, buildProps)
 		},
 	}
@@ -64,6 +70,9 @@ func getAddLibCmd(env *CommandEnv) *cobra.Command {
 		Aliases: []string{"libs", "lib", "library"},
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			for _, l := range args {
 				env.Logger.Infof("Adding library: %s", l)
 				name, vers, err := env.ArdiCore.Lib.Add(l)
@@ -91,6 +100,9 @@ func getAddBoardURLCmd(env *CommandEnv) *cobra.Command {
 		Aliases: []string{"board-urls"},
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			for _, u := range args {
 				if err := env.ArdiCore.Config.AddBoardURL(u); err != nil {
 					return err

--- a/v2/commands/attach_and_watch.go
+++ b/v2/commands/attach_and_watch.go
@@ -16,13 +16,16 @@ func getWatchCmd(env *CommandEnv) *cobra.Command {
 	var watchCmd = &cobra.Command{
 		Use:     "attach-and-watch [sketch|build]",
 		Aliases: []string{"develop", "dev"},
-		Short:   "Compile, upload, watch board logs, and watch for sketch changes",
+		Short:   "Compile, upload, attach, and watch for changes",
 		Long: "\nCompile, upload, watch board logs, and watch for sketch " +
 			"changes. Updates to the sketch file will trigger automatic recompile, " +
 			"reupload, and restarts the board log watcher. If the sketch argument " +
 			"matches a user defined build in ardi.json, the build values will be " +
 			"used for compilation, upload, and watch path",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			optsList, err := env.ArdiCore.GetCompileOptsFromArgs(fqbn, buildProps, false, args)
 			if err != nil {
 				return err

--- a/v2/commands/compile.go
+++ b/v2/commands/compile.go
@@ -22,6 +22,9 @@ func getCompileCmd(env *CommandEnv) *cobra.Command {
 		Short:   "Compile specified sketch or build(s)",
 		Aliases: []string{"build"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			defer env.ArdiCore.Compiler.StopWatching() // noop if not watching
 
 			board, _ := env.ArdiCore.Cli.GetTargetBoard(fqbn, "", true)

--- a/v2/commands/compile_and_upload.go
+++ b/v2/commands/compile_and_upload.go
@@ -23,6 +23,9 @@ func getCompileAndUploadCmd(env *CommandEnv) *cobra.Command {
 			"build in ardi.json, the values defined in build will be used to " +
 			"compile and upload.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			optsList, err := env.ArdiCore.GetCompileOptsFromArgs(fqbn, buildProps, false, args)
 			if err != nil {
 				return err

--- a/v2/commands/install.go
+++ b/v2/commands/install.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"fmt"
 
-	"github.com/robgonnella/ardi/v2/util"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +12,7 @@ func getInstallCmd(env *CommandEnv) *cobra.Command {
 		Short: "Install all project dependencies",
 		Long:  "\nInstall all project dependencies",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := util.InitProjectDirectory(); err != nil {
+			if err := requireProjectInit(); err != nil {
 				return err
 			}
 			for _, url := range env.ArdiCore.Config.GetBoardURLS() {

--- a/v2/commands/list.go
+++ b/v2/commands/list.go
@@ -9,6 +9,9 @@ func getListPlatformCmd(env *CommandEnv) *cobra.Command {
 		Short:   "List project platforms",
 		Aliases: []string{"platform"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			env.Logger.Info("Platforms specified in ardi.json")
 			env.ArdiCore.Config.ListPlatforms()
 
@@ -30,6 +33,9 @@ func getListLibrariesCmd(env *CommandEnv) *cobra.Command {
 		Short:   "List project libraries",
 		Aliases: []string{"libs"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			env.Logger.Info("Libraries specified in ardi.json")
 			env.ArdiCore.Config.ListLibraries()
 			env.Logger.Info("Installed libraries")
@@ -48,8 +54,12 @@ func getListBuildsCmd(env *CommandEnv) *cobra.Command {
 		Long:    "\nList project builds",
 		Short:   "List project builds",
 		Aliases: []string{"build"},
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			env.ArdiCore.Config.ListBuilds(args)
+			return nil
 		},
 	}
 	return listCmd
@@ -60,8 +70,12 @@ func getListBoardURLSCmd(env *CommandEnv) *cobra.Command {
 		Use:   "board-urls",
 		Long:  "\nList project board urls",
 		Short: "List project board urls",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			env.ArdiCore.Config.ListBoardURLS()
+			return nil
 		},
 	}
 	return listCmd
@@ -73,6 +87,9 @@ func getListBoardFQBNSCmd(env *CommandEnv) *cobra.Command {
 		Long:  "\nList boards with associated fqbns",
 		Short: "List boards with associated fqbns",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			query := ""
 			if len(args) > 0 {
 				query = args[0]
@@ -89,6 +106,9 @@ func getListBoardPlatformsCmd(env *CommandEnv) *cobra.Command {
 		Long:  "\nList boards with their associated platform",
 		Short: "List boards with their associated platform",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			query := ""
 			if len(args) > 0 {
 				query = args[0]

--- a/v2/commands/remove.go
+++ b/v2/commands/remove.go
@@ -10,6 +10,9 @@ func getRemovePlatformCmd(env *CommandEnv) *cobra.Command {
 		Aliases: []string{"platform"},
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			for _, p := range args {
 				env.Logger.Infof("Removing platform: %s", p)
 				removed, err := env.ArdiCore.Platform.Remove(p)
@@ -36,6 +39,9 @@ func getRemoveBuildCmd(env *CommandEnv) *cobra.Command {
 		Aliases: []string{"build"},
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			for _, b := range args {
 				if err := env.ArdiCore.Config.RemoveBuild(b); err != nil {
 					return err
@@ -55,6 +61,9 @@ func getRemoveLibCmd(env *CommandEnv) *cobra.Command {
 		Aliases: []string{"libs", "lib", "library"},
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			for _, l := range args {
 				env.Logger.Infof("Removing library: %s", l)
 				if err := env.ArdiCore.Lib.Remove(l); err != nil {
@@ -80,6 +89,9 @@ func getRemoveBoardURLCmd(env *CommandEnv) *cobra.Command {
 		Aliases: []string{"board-url"},
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			for _, url := range args {
 				if err := env.ArdiCore.Config.RemoveBoardURL(url); err != nil {
 					return err

--- a/v2/commands/root.go
+++ b/v2/commands/root.go
@@ -58,42 +58,11 @@ func setLogger(env *CommandEnv) {
 	log.SetOutput(ioutil.Discard)
 }
 
-func cmdIsProjectInit(cmd string) bool {
-	return cmd == "ardi project-init"
-}
-
-func cmdIsHelp(cmd string) bool {
-	return strings.Contains(cmd, "help")
-}
-
-func cmdIsVersion(cmd string) bool {
-	return cmd == "ardi version"
-}
-
-func cmdIsArdiAttach(cmd string) bool {
-	return cmd == "ardi attach"
-}
-
-func shouldShowProjectError(cmd string) bool {
-	return !util.IsProjectDirectory() &&
-		!cmdIsProjectInit(cmd) &&
-		!cmdIsArdiAttach(cmd) &&
-		!cmdIsHelp(cmd) &&
-		!cmdIsVersion(cmd)
-}
-
-func getPreRun(env *CommandEnv) func(cmd *cobra.Command, args []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		setLogger(env)
-
-		cmdPath := cmd.CommandPath()
-
-		if shouldShowProjectError(cmdPath) {
-			return errors.New("not an ardi project directory, run 'ardi project-init' first")
-		}
-
-		return nil
+func requireProjectInit() error {
+	if !util.IsProjectDirectory() {
+		return errors.New("not an ardi project directory, run 'ardi project-init' first")
 	}
+	return nil
 }
 
 func getRootCommand(env *CommandEnv) *cobra.Command {
@@ -104,7 +73,6 @@ func getRootCommand(env *CommandEnv) *cobra.Command {
 			"- Manage and store build configurations for projects with versioned dependencies\n- Run builds in CI Pipeline\n" +
 			"- Compile & upload sketches to connected boards\n- Watch log output from connected boards in terminal\n" +
 			"- Auto recompile / reupload on save",
-		PersistentPreRunE: getPreRun(env),
 		DisableAutoGenTag: true,
 	}
 
@@ -116,19 +84,22 @@ func getRootCommand(env *CommandEnv) *cobra.Command {
 
 // GetRootCmd adds all ardi commands to root and returns root command
 func GetRootCmd(env *CommandEnv) *cobra.Command {
+	setLogger(env)
 	rootCmd := getRootCommand(env)
-	rootCmd.AddCommand(getAddCmd(env))
-	rootCmd.AddCommand(getCleanCmd(env))
-	rootCmd.AddCommand(getCompileCmd(env))
-	rootCmd.AddCommand(getCompileAndUploadCmd(env))
-	rootCmd.AddCommand(getInstallCmd(env))
-	rootCmd.AddCommand(getListCmd(env))
-	rootCmd.AddCommand(getProjectInitCmd(env))
-	rootCmd.AddCommand(getRemoveCmd(env))
-	rootCmd.AddCommand(getSearchCmd(env))
-	rootCmd.AddCommand(getUploadCmd(env))
-	rootCmd.AddCommand(getVersionCmd(env))
-	rootCmd.AddCommand(getWatchCmd(env))
-	rootCmd.AddCommand(getAttachCmd(env))
+	rootCmd.AddCommand(
+		getAddCmd(env),
+		getCleanCmd(env),
+		getCompileCmd(env),
+		getCompileAndUploadCmd(env),
+		getInstallCmd(env),
+		getListCmd(env),
+		getProjectInitCmd(env),
+		getRemoveCmd(env),
+		getSearchCmd(env),
+		getUploadCmd(env),
+		getVersionCmd(env),
+		getWatchCmd(env),
+		getAttachCmd(env),
+	)
 	return rootCmd
 }

--- a/v2/commands/search.go
+++ b/v2/commands/search.go
@@ -9,6 +9,9 @@ func getSearchPlatformCmd(env *CommandEnv) *cobra.Command {
 		Short:   "Search all available platforms",
 		Aliases: []string{"platform"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			env.Logger.Info("Available platforms")
 			if err := env.ArdiCore.Platform.ListAll(); err != nil {
 				return err
@@ -26,6 +29,9 @@ func getSearchLibCmd(env *CommandEnv) *cobra.Command {
 		Short:   "Searches for availables libraries with optional search filter",
 		Aliases: []string{"lib", "libs", "library"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			searchArg := ""
 			if len(args) > 0 {
 				searchArg = args[0]

--- a/v2/commands/upload.go
+++ b/v2/commands/upload.go
@@ -17,6 +17,9 @@ func getUploadCmd(env *CommandEnv) *cobra.Command {
 			"build values will be used to find the appropraite build to upload",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireProjectInit(); err != nil {
+				return err
+			}
 			defer env.ArdiCore.Uploader.Detach() // noop if not attached
 
 			baud = env.ArdiCore.GetBaudFromArgs(baud, args)


### PR DESCRIPTION
The persistent pre run was causing completions to not work by
returning an error for uninitialized project directories